### PR TITLE
No need to install webpack globally, use ./node_modules/.bin instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ cd simple-webpack-boilerplate
 
 # Install dependencies
 npm install
-npm install webpack webpack-dev-server -g
 ```
 
 ### Dev

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Webpack4 + ES6 + LESS + PostCSS Boilerplate",
   "main": "webpack.config.js",
   "scripts": {
-    "build": "webpack -p",
-    "dev": "webpack-dev-server -d --content-base dist"
+    "build": "./node_modules/.bin/webpack -p",
+    "dev": "./node_modules/.bin/webpack-dev-server -d --content-base dist --port 8081"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there!

I was using your boilerplate as a launchpad for something I'm working on, and noticed something -

Noticed your boilerplate adds an unnecessary step, and installing packages globally can lead to headaches down the road. By using the bin file, you won't have to worry whether the user's version of webpack is different than the version of webpack required for this repo.

Cheers,
Jimmy